### PR TITLE
Add a synchronous renderToDataURL function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,22 @@ export class CanvasRenderService {
 	}
 
 	/**
+	 * Render to a data url.
+	 * @see https://github.com/Automattic/node-canvas#canvastodataurl
+	 *
+	 * @param configuration The Chart JS configuration for the chart to render.
+	 * @param mimeType The image format, `image/png` or `image/jpeg`.
+	 */
+	public renderToDataURLSync(configuration: ChartConfiguration, mimeType: MimeType = 'image/png'): string {
+		
+		const chart = this.renderChart(configuration);
+		const canvas = chart.canvas as any;
+		const result = canvas.toDataURL(mimeType) as string;
+		chart.destory();
+		return result;
+	}
+
+	/**
 	 * Render to a buffer.
 	 * @see https://github.com/Automattic/node-canvas#canvastobuffer
 	 *


### PR DESCRIPTION
Although the canvas supports returning the result synchronously, this library lacked a way to use that functionality. This PR adds it.