### PR TITLE
fix renderToDataURLSync: destory chart after generating data URL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,8 +90,8 @@ export class CanvasRenderService {
 			throw new Error('Canvas is null');
 		}
 		const canvas = chart.canvas as Canvas;
-		chart.destroy();
 		const dataUrl = canvas.toDataURL(mimeType);
+		chart.destroy();
 		return dataUrl;
 	}
 


### PR DESCRIPTION
`destroy()` ends up clearing the canvas ([see here](https://github.com/chartjs/Chart.js/blob/master/src/core/core.controller.js#L921)) so it must be called after the data URL generation.

This fixes `renderToDataURLSync` always returning an empty image.