### PR TITLE
chore(deps): update canvas, tslib, chart.js v3, fix build

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node-version: ['10.x', '12.x', '14.x', '16.x']
+        node-version: ['14.x', '16.x', '18.x', '20.x']
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -59,7 +59,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node-version: ['16.x']
+        node-version: ['20.x']
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "4.1.6",
       "license": "MIT",
       "dependencies": {
-        "canvas": "^2.8.0",
-        "tslib": "^2.3.1"
+        "canvas": "^2.11.2",
+        "tslib": "^2.6.2"
       },
       "devDependencies": {
         "@types/mocha": "^7.0.2",
@@ -21,7 +21,6 @@
         "chartjs-plugin-annotation": "^1.0.2",
         "chartjs-plugin-crosshair": "^1.2.0",
         "chartjs-plugin-datalabels": "^2.0.0",
-        "chartjs-plugin-piechart-outlabels": "^0.1.4",
         "clean-dest": "^1.3.3",
         "jsdoc-to-markdown": "^5.0.3",
         "mocha": "^7.2.0",
@@ -32,8 +31,6 @@
         "ts-std-lib": "^1.2.1",
         "tslint": "^6.1.3",
         "tslint-divid": "^1.3.0",
-        "tslint-eslint-rules": "^5.4.0",
-        "tslint-immutable": "^6.0.1",
         "typescript": "^4.4.4",
         "wtfnode": "^0.9.1"
       },
@@ -1281,13 +1278,13 @@
       }
     },
     "node_modules/canvas": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.8.0.tgz",
-      "integrity": "sha512-gLTi17X8WY9Cf5GZ2Yns8T5lfBOcGgFehDFb+JQwDqdOoBOcECS9ZWMEAqMSVcMYwXD659J8NyzjRY/2aE+C2Q==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.14.0",
+        "nan": "^2.17.0",
         "simple-get": "^3.0.3"
       },
       "engines": {
@@ -1357,15 +1354,6 @@
       "dev": true,
       "peerDependencies": {
         "chart.js": "^3.0.0"
-      }
-    },
-    "node_modules/chartjs-plugin-piechart-outlabels": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-piechart-outlabels/-/chartjs-plugin-piechart-outlabels-0.1.4.tgz",
-      "integrity": "sha1-6X4ZoSIC10+QQNnkZBmHydHkWPw=",
-      "dev": true,
-      "peerDependencies": {
-        "chart.js": ">= 2.7.0 < 3"
       }
     },
     "node_modules/chokidar": {
@@ -2200,34 +2188,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/doctrine": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
-      "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^1.1.6",
-        "isarray": "0.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/doctrine/node_modules/esutils": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-      "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/doctrine/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -4508,9 +4468,9 @@
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -5879,6 +5839,22 @@
         "canvas": "2.8.0"
       }
     },
+    "node_modules/resemblejs/node_modules/canvas": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.8.0.tgz",
+      "integrity": "sha512-gLTi17X8WY9Cf5GZ2Yns8T5lfBOcGgFehDFb+JQwDqdOoBOcECS9ZWMEAqMSVcMYwXD659J8NyzjRY/2aE+C2Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.14.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
@@ -6718,9 +6694,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tslint": {
       "version": "6.1.3",
@@ -6758,55 +6734,6 @@
       "resolved": "https://registry.npmjs.org/tslint-divid/-/tslint-divid-1.3.0.tgz",
       "integrity": "sha512-troGy/RDBC888Ew1efm03vu8o04WCw4xMLN9ZXqou1hPUv2D9sNsBubLZrGNdCNolOV+wOMSc7QEcQrlrbkD1w==",
       "dev": true
-    },
-    "node_modules/tslint-eslint-rules": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz",
-      "integrity": "sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==",
-      "dev": true,
-      "dependencies": {
-        "doctrine": "0.7.2",
-        "tslib": "1.9.0",
-        "tsutils": "^3.0.0"
-      },
-      "peerDependencies": {
-        "tslint": "^5.0.0",
-        "typescript": "^2.2.0 || ^3.0.0"
-      }
-    },
-    "node_modules/tslint-eslint-rules/node_modules/tslib": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-      "dev": true
-    },
-    "node_modules/tslint-eslint-rules/node_modules/tsutils": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.3.1.tgz",
-      "integrity": "sha512-reuFQ3/EoMy70YvBPrxe9p7LvA4dCQnvMn+LV8Tv2NKkLCKRHgfB4qFTA9NtWlyYSldTu1dukuquQ3o0mLvsPw==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev"
-      }
-    },
-    "node_modules/tslint-immutable": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tslint-immutable/-/tslint-immutable-6.0.1.tgz",
-      "integrity": "sha512-3GQ6HffN64gLmT/N1YzyVMqyf6uBjMvhNaevK8B0K01/QC0OU5AQZrH4TjMHo1IdG3JpqsZvuRy9IW1LA3zjwA==",
-      "dev": true,
-      "dependencies": {
-        "tsutils": "^2.28.0 || ^3.0.0"
-      },
-      "peerDependencies": {
-        "tslint": "^5.8.0",
-        "typescript": "^2.8.0 || ^3.0.0"
-      }
     },
     "node_modules/tslint/node_modules/diff": {
       "version": "4.0.2",
@@ -8722,12 +8649,12 @@
       "dev": true
     },
     "canvas": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.8.0.tgz",
-      "integrity": "sha512-gLTi17X8WY9Cf5GZ2Yns8T5lfBOcGgFehDFb+JQwDqdOoBOcECS9ZWMEAqMSVcMYwXD659J8NyzjRY/2aE+C2Q==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.14.0",
+        "nan": "^2.17.0",
         "simple-get": "^3.0.3"
       }
     },
@@ -8783,13 +8710,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.0.0.tgz",
       "integrity": "sha512-WBsWihphzM0Y8fmQVm89+iy99mmgejmj5/jcsYqwxSioLRL/zqJ4Scv/eXq5ZqvG3TpojlGzZLeaOaSvDm7fwA==",
-      "dev": true,
-      "requires": {}
-    },
-    "chartjs-plugin-piechart-outlabels": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/chartjs-plugin-piechart-outlabels/-/chartjs-plugin-piechart-outlabels-0.1.4.tgz",
-      "integrity": "sha1-6X4ZoSIC10+QQNnkZBmHydHkWPw=",
       "dev": true,
       "requires": {}
     },
@@ -9453,30 +9373,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-3.0.0.tgz",
           "integrity": "sha512-eczl8wAYBxJ6Egl6I1ECIF+8z6sHu+KE7BzaEDZTpPXKXfy9SUDQlVYwkRcNTjJLC3Iakxbhss50KuT/R6SYfg==",
-          "dev": true
-        }
-      }
-    },
-    "doctrine": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
-      "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
-      "dev": true,
-      "requires": {
-        "esutils": "^1.1.6",
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "esutils": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
       }
@@ -11206,9 +11102,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "neo-async": {
       "version": "2.6.2",
@@ -12235,6 +12131,20 @@
       "dev": true,
       "requires": {
         "canvas": "2.8.0"
+      },
+      "dependencies": {
+        "canvas": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.8.0.tgz",
+          "integrity": "sha512-gLTi17X8WY9Cf5GZ2Yns8T5lfBOcGgFehDFb+JQwDqdOoBOcECS9ZWMEAqMSVcMYwXD659J8NyzjRY/2aE+C2Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@mapbox/node-pre-gyp": "^1.0.0",
+            "nan": "^2.14.0",
+            "simple-get": "^3.0.3"
+          }
+        }
       }
     },
     "resolve": {
@@ -12888,9 +12798,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tslint": {
       "version": "6.1.3",
@@ -12947,43 +12857,6 @@
       "resolved": "https://registry.npmjs.org/tslint-divid/-/tslint-divid-1.3.0.tgz",
       "integrity": "sha512-troGy/RDBC888Ew1efm03vu8o04WCw4xMLN9ZXqou1hPUv2D9sNsBubLZrGNdCNolOV+wOMSc7QEcQrlrbkD1w==",
       "dev": true
-    },
-    "tslint-eslint-rules": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz",
-      "integrity": "sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==",
-      "dev": true,
-      "requires": {
-        "doctrine": "0.7.2",
-        "tslib": "1.9.0",
-        "tsutils": "^3.0.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-          "dev": true
-        },
-        "tsutils": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.3.1.tgz",
-          "integrity": "sha512-reuFQ3/EoMy70YvBPrxe9p7LvA4dCQnvMn+LV8Tv2NKkLCKRHgfB4qFTA9NtWlyYSldTu1dukuquQ3o0mLvsPw==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        }
-      }
-    },
-    "tslint-immutable": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tslint-immutable/-/tslint-immutable-6.0.1.tgz",
-      "integrity": "sha512-3GQ6HffN64gLmT/N1YzyVMqyf6uBjMvhNaevK8B0K01/QC0OU5AQZrH4TjMHo1IdG3JpqsZvuRy9IW1LA3zjwA==",
-      "dev": true,
-      "requires": {
-        "tsutils": "^2.28.0 || ^3.0.0"
-      }
     },
     "tsutils": {
       "version": "2.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/node": "^16.10.4",
         "@types/offscreencanvas": "^2019.6.4",
         "c8": "^7.10.0",
-        "chart.js": "^3.5.1",
+        "chart.js": "^3.9.1",
         "chartjs-plugin-annotation": "^1.0.2",
         "chartjs-plugin-crosshair": "^1.2.0",
         "chartjs-plugin-datalabels": "^2.0.0",
@@ -35,7 +35,7 @@
         "wtfnode": "^0.9.1"
       },
       "peerDependencies": {
-        "chart.js": "^3.5.1"
+        "chart.js": "^3.9.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1324,9 +1324,9 @@
       "dev": true
     },
     "node_modules/chart.js": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.5.1.tgz",
-      "integrity": "sha512-m5kzt72I1WQ9LILwQC4syla/LD/N413RYv2Dx2nnTkRS9iv/ey1xLTt0DnPc/eWV4zI+BgEgDYBIzbQhZHc/PQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.9.1.tgz",
+      "integrity": "sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==",
       "dev": true
     },
     "node_modules/chartjs-plugin-annotation": {
@@ -8687,9 +8687,9 @@
       "dev": true
     },
     "chart.js": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.5.1.tgz",
-      "integrity": "sha512-m5kzt72I1WQ9LILwQC4syla/LD/N413RYv2Dx2nnTkRS9iv/ey1xLTt0DnPc/eWV4zI+BgEgDYBIzbQhZHc/PQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.9.1.tgz",
+      "integrity": "sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==",
       "dev": true
     },
     "chartjs-plugin-annotation": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "readme": "README.md",
   "license": "MIT",
   "dependencies": {
-    "canvas": "^2.8.0",
-    "tslib": "^2.3.1"
+    "canvas": "^2.11.2",
+    "tslib": "^2.6.2"
   },
   "peerDependencies": {
     "chart.js": "^3.5.1"
@@ -50,7 +50,6 @@
     "chartjs-plugin-annotation": "^1.0.2",
     "chartjs-plugin-crosshair": "^1.2.0",
     "chartjs-plugin-datalabels": "^2.0.0",
-    "chartjs-plugin-piechart-outlabels": "^0.1.4",
     "clean-dest": "^1.3.3",
     "jsdoc-to-markdown": "^5.0.3",
     "mocha": "^7.2.0",
@@ -61,8 +60,6 @@
     "ts-std-lib": "^1.2.1",
     "tslint": "^6.1.3",
     "tslint-divid": "^1.3.0",
-    "tslint-eslint-rules": "^5.4.0",
-    "tslint-immutable": "^6.0.1",
     "typescript": "^4.4.4",
     "wtfnode": "^0.9.1"
   }

--- a/package.json
+++ b/package.json
@@ -39,14 +39,14 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "chart.js": "^3.5.1"
+    "chart.js": "^3.9.1"
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
     "@types/node": "^16.10.4",
     "@types/offscreencanvas": "^2019.6.4",
     "c8": "^7.10.0",
-    "chart.js": "^3.5.1",
+    "chart.js": "^3.9.1",
     "chartjs-plugin-annotation": "^1.0.2",
     "chartjs-plugin-crosshair": "^1.2.0",
     "chartjs-plugin-datalabels": "^2.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,7 @@ export class ChartJSNodeCanvas {
 		configuration.options = configuration.options || {};
 		configuration.options.responsive = false;
 		configuration.options.animation = false as any;
-		const context = canvas.getContext('2d');
+		const context = canvas.getContext('2d') as any;
 		(global as any).Image = this._image; // Some plugins use this API
 		const chart = new this._chartJs(context, configuration);
 		delete (global as any).Image;


### PR DESCRIPTION
- Update canvas and tslib deps
- Update chart.js to latest v3
- Remove non existing deps
- Fix build due to tsc error

Before this PR if trying to `npm i` and `npm run build`: https://pastebin.com/rwJNN9Pk

cc @SeanSobey 